### PR TITLE
fix GitHub Workflow to check syntax with Vale

### DIFF
--- a/.github/workflows/check-syntax.yml
+++ b/.github/workflows/check-syntax.yml
@@ -10,15 +10,9 @@ jobs:
       - name: Checkout this repository
         uses: actions/checkout@v3.5.3
 
-      - name: Get latest version of Vale
-        id: lastversion
-        uses: dvershinin/lastversion-action@v0.0.3
-        with:
-          repository: errata-ai/vale
-
       - name: Install Vale
         run: |
-          wget https://github.com/errata-ai/vale/releases/download/v${{ steps.lastversion.outputs.last_version }}/vale_${{ steps.lastversion.outputs.last_version }}_Linux_64-bit.tar.gz -O vale.tar.gz
+          wget https://github.com/errata-ai/vale/releases/download/v2.30.0/vale_2.30.0_Linux_64-bit.tar.gz -O vale.tar.gz
           tar -xvzf vale.tar.gz vale
           rm vale.tar.gz
 


### PR DESCRIPTION
Not using latest version, and pin to a specific version.